### PR TITLE
Plannerのマイページ作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,3 +142,7 @@ Style/RegexpLiteral:
 # https://rubocop.readthedocs.io/en/stable/cops_style/#styleslicingwithrange
 Style/SlicingWithRange:
   Enabled: true
+
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/SpaceInsideBlockBraces
+Style/SpaceInsideBlockBraces:
+  EnforcedStyle: space

--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 
-  # 追加
-  gem 'rspec-rails', '~> 5.0.0'
-  gem 'factory_bot_rails'
 end
 
 group :development do
@@ -60,6 +57,10 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
+  
+  # 追加
+  gem 'rspec-rails', '~> 5.0.0'
+  gem 'factory_bot_rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
 
   # 追加
   gem 'rspec-rails', '~> 5.0.0'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.10.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -269,6 +274,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pry-rails

--- a/app/assets/stylesheets/planners.scss
+++ b/app/assets/stylesheets/planners.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the planners controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,20 +1,16 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # ログイン後遷移先指定
   def after_sign_in_path_for(resource)
-    # FPの場合はFPのマイページに飛ばす
     planner_path(current_planner.id) if planner_signed_in?
-    # クライアントの場合はクライアントのマイページに飛ばす
     client_path(current_client.id) if client_signed_in?
   end
   
-  # ログアウト後後遷移先指定
   def after_sign_out_path_for(resource)
     if resource == :planner
-        top_fp_path
+      top_fp_path
     else
-        root_path
+      root_path
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,15 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  # ログイン後遷移先指定
   def after_sign_in_path_for(resource)
     # FPの場合はFPのマイページに飛ばす
     planner_path(current_planner.id) if planner_signed_in?
     # クライアントの場合はクライアントのマイページに飛ばす
     client_path(current_client.id) if client_signed_in?
   end
-
+  
+  # ログアウト後後遷移先指定
   def after_sign_out_path_for(resource)
       if resource == :planner
           top_fp_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,21 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_in_path_for(resource)
+    # FPの場合はFPのマイページに飛ばす
+    planner_path(current_planner.id) if planner_signed_in?
+    # クライアントの場合はクライアントのマイページに飛ばす
+    client_path(current_client.id) if client_signed_in?
+  end
+
+  def after_sign_out_path_for(resource)
+      if resource == :planner
+          top_fp_path
+      else
+          root_path
+      end
+  end
+
   protected
 
   # ユーザー登録時に名前を登録できるようにする

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,7 @@ class ApplicationController < ActionController::Base
   end
   
   def after_sign_out_path_for(resource)
-    if resource == :planner
-      top_fp_path
-    else
-      root_path
-    end
+    resource == :planner ? top_fp_path : root_path
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,11 +11,11 @@ class ApplicationController < ActionController::Base
   
   # ログアウト後後遷移先指定
   def after_sign_out_path_for(resource)
-      if resource == :planner
-          top_fp_path
-      else
-          root_path
-      end
+    if resource == :planner
+        top_fp_path
+    else
+        root_path
+    end
   end
 
   protected

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -1,4 +1,5 @@
 class PlannersController < ApplicationController
+  # Pllannerでログインしていなければsign_inページにリダイレクトされる
   before_action :authenticate_planner!
 
   def show

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -1,5 +1,8 @@
 class PlannersController < ApplicationController
+  before_action :authenticate_planner!
+
   def show
+    @planner = Planner.find(params[:id])
   end
 
   def edit

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -1,0 +1,7 @@
+class PlannersController < ApplicationController
+  def show
+  end
+
+  def edit
+  end
+end

--- a/app/helpers/planners_helper.rb
+++ b/app/helpers/planners_helper.rb
@@ -1,0 +1,2 @@
+module PlannersHelper
+end

--- a/app/views/home/top_fp.html.erb
+++ b/app/views/home/top_fp.html.erb
@@ -1,1 +1,4 @@
+<div>
+<%= render "shared/list_fp" %>
+</div>
 FP用トップページ

--- a/app/views/planners/edit.html.erb
+++ b/app/views/planners/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Planners#edit</h1>
+<p>Find me in app/views/planners/edit.html.erb</p>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -1,1 +1,5 @@
-<h1>プランナーID：<%= @planner.id %></h1>
+<div>
+  <%= render "shared/list_fp" %>
+</div>
+
+<h1>ニックネーム：<%= @planner.name %></h1>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -1,1 +1,1 @@
-<h1>Planners#show</h1>
+<h1>プランナーID：<%= @planner.id %></h1>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Planners#show</h1>

--- a/app/views/shared/_list_fp.html.erb
+++ b/app/views/shared/_list_fp.html.erb
@@ -1,7 +1,7 @@
 <% if planner_signed_in? %> 
-    <%= link_to "ログアウト", destroy_planner_session_path , method: :delete %>
+  <%= link_to "ログアウト", destroy_planner_session_path , method: :delete %>
 <% else %>
-    <%= link_to "新規登録", new_planner_registration_path %>
-    <%= link_to "ログイン", new_planner_session_path %>
-    <%= link_to "一般の方はこちら", root_path %>
+  <%= link_to "新規登録", new_planner_registration_path %>
+  <%= link_to "ログイン", new_planner_session_path %>
+  <%= link_to "一般の方はこちら", root_path %>
 <% end %>

--- a/app/views/shared/_list_fp.html.erb
+++ b/app/views/shared/_list_fp.html.erb
@@ -1,0 +1,7 @@
+<% if planner_signed_in? %> 
+    <%= link_to "ログアウト", destroy_planner_session_path , method: :delete %>
+<% else %>
+    <%= link_to "新規登録", new_planner_registration_path %>
+    <%= link_to "ログイン", new_planner_session_path %>
+    <%= link_to "一般の方はこちら", root_path %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
-  get 'planners/show'
-  get 'planners/edit'
-  devise_for :planners
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   devise_for :clients
   root "home#top"
   get "/top_fp" => "home#top_fp"
+  
+  devise_for :planners
+  resources :planners, only: [:show, :edit]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'planners/show'
+  get 'planners/edit'
   devise_for :planners
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   devise_for :clients

--- a/spec/factories/planners.rb
+++ b/spec/factories/planners.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :planner do
-    email                           {"a@a"}
-    password                        {"abc1234"}
-    name                            {"ニックネーム"}
+    email                           { "a@a" }
+    password                        { "abc1234" }
+    name                            { "ニックネーム" }
   end
 end

--- a/spec/factories/planners.rb
+++ b/spec/factories/planners.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :planner do
+    email                           {"a@a"}
+    password                        {"abc1234"}
+    name                            {"ニックネーム"}
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # deviseのヘルパー機能を呼び出す(sign_inを利用したかった)
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/planners_spec.rb
+++ b/spec/requests/planners_spec.rb
@@ -1,18 +1,28 @@
 require 'rails_helper'
 
-RSpec.describe "Planners", type: :request do
-  describe "GET /show" do
-    it "returns http success" do
-      get "/planners/show"
-      expect(response).to have_http_status(:success)
+RSpec.describe Planner, type: :request do
+  describe "マイページのアクセス" do
+    before do
+      @planner = FactoryBot.create(:planner)
+    end
+    context "ログイン前" do
+      it "sign_inにリダイレクトされる" do
+        get planner_path(@planner.id)
+        expect(response).to redirect_to new_planner_session_path
+      end
+    end
+    context "ログイン後" do
+      before do
+        sign_in @planner
+      end
+      it "正常なレスポンスが返ってくる(200)" do
+        get planner_path(@planner.id)
+        expect(response.status).to eq 200
+      end
+      it "plannerのnameが表示される" do
+        get planner_path(@planner.id)
+        expect(response.body).to include @planner.name
+      end
     end
   end
-
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/planners/edit"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/requests/planners_spec.rb
+++ b/spec/requests/planners_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Planners", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/planners/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/planners/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 対応issue
close #34

## この PR で対応したこと
### Planner controllerとviewを作成
rails g controller planners show edit コマンドで自動生成
※編集ページは未対応
![image](https://user-images.githubusercontent.com/42030915/118246121-8c06e900-b4dc-11eb-9bb0-d0cf63649109.png)

### ログイン後・ログアウト後の遷移ページ指定
参考：https://www.rubydoc.info/github/plataformatec/devise/Devise%2FControllers%2FHelpers:after_sign_in_path_for
### ログイン前後のアクセスに関するRSpecの記述
ログイン前にマイページへアクセスするとリダイレクトされるのか
ログイン後にマイページにアクセスできるのか
ヘルパーについて[参照元](https://github.com/heartcombo/devise#integration-tests)