### PR TITLE
テーブル作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'app/views/**/*.jbuilder'
     - 'lib/tasks/dev.rake'
+    - 'db/schema.rb'
 
 Metrics/ClassLength:
   CountComments: false

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -1,0 +1,4 @@
+class ReservationFrame < ApplicationRecord
+  belongs_to :planner
+  belongs_to :time_frame
+end

--- a/app/models/time_frame.rb
+++ b/app/models/time_frame.rb
@@ -1,0 +1,2 @@
+class TimeFrame < ApplicationRecord
+end

--- a/db/migrate/20210517044606_create_time_frames.rb
+++ b/db/migrate/20210517044606_create_time_frames.rb
@@ -1,0 +1,10 @@
+class CreateTimeFrames < ActiveRecord::Migration[6.1]
+  def change
+    create_table :time_frames do |t|
+      t.time :start_at
+      t.time :end_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210517044615_create_reservation_frames.rb
+++ b/db/migrate/20210517044615_create_reservation_frames.rb
@@ -1,0 +1,12 @@
+class CreateReservationFrames < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reservation_frames do |t|
+      t.date :date
+      t.boolean :is_deleted
+      t.references :planner, null: false, foreign_key: true
+      t.references :time_frame, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_10_032609) do
+ActiveRecord::Schema.define(version: 2021_05_17_044615) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -38,4 +38,24 @@ ActiveRecord::Schema.define(version: 2021_05_10_032609) do
     t.index ["reset_password_token"], name: "index_planners_on_reset_password_token", unique: true
   end
 
+  create_table "reservation_frames", force: :cascade do |t|
+    t.date "date"
+    t.boolean "is_deleted"
+    t.integer "planner_id", null: false
+    t.integer "time_frame_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planner_id"], name: "index_reservation_frames_on_planner_id"
+    t.index ["time_frame_id"], name: "index_reservation_frames_on_time_frame_id"
+  end
+
+  create_table "time_frames", force: :cascade do |t|
+    t.time "start_at"
+    t.time "end_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "reservation_frames", "planners"
+  add_foreign_key "reservation_frames", "time_frames"
 end

--- a/spec/models/reservation_frame_spec.rb
+++ b/spec/models/reservation_frame_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ReservationFrame, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/time_frame_spec.rb
+++ b/spec/models/time_frame_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TimeFrame, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 対応issue
親issue：#14
close #15 
## issueの要約&このPRの目的
clientがplannerの時間を抑えるために、planner側で受付可能な日時を指定する予約枠を作成できるようにする。
そのためにまず必要なテーブルを作成するというのがこのPRの目的。
## このPRで対応したこと
### ①テーブル作成
![image](https://user-images.githubusercontent.com/42030915/118397455-05ded400-b68f-11eb-923f-23da95bd6fee.png)
#### time_frame(時間枠)
- 予約受付可能な時間帯に関するデータ
- seedファイルで初期データを投入する想定
- データ更新はDBを直接更新
- rails コマンドで生成(commit message参照)
#### reservation_frame(予約枠)
- どのplnannerがどの時間枠を受付可能にするかを管理
- 時間枠テーブルとplannerテーブルの中間テーブル(予約枠)
- rails コマンドで生成(commit message参照)
→参考：[railsガイド](https://railsguides.jp/active_record_migrations.html#%E5%8D%98%E7%8B%AC%E3%81%AE%E3%83%9E%E3%82%A4%E3%82%B0%E3%83%AC%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)
### ②rubocop設定
schema.rbに対してMetrics/BlockLengthが出たので、スルーするように設定
(自動生成で記述することがないため)
## レビュアーに注意して見てほしいこと
- PRの書き方が伝わりやすいかどうか