### PR TITLE
seedを使って時間枠データを作成

### DIFF
--- a/db/migrate/20210517060821_change_column_time_frame.rb
+++ b/db/migrate/20210517060821_change_column_time_frame.rb
@@ -1,0 +1,6 @@
+class ChangeColumnTimeFrame < ActiveRecord::Migration[6.1]
+  def change
+    change_column :time_frames, :start_at, :string
+    change_column :time_frames, :end_at, :string
+  end
+end

--- a/db/migrate/20210517060821_change_column_time_frame.rb
+++ b/db/migrate/20210517060821_change_column_time_frame.rb
@@ -1,6 +1,6 @@
 class ChangeColumnTimeFrame < ActiveRecord::Migration[6.1]
-  def change
-    change_column :time_frames, :start_at, :string
-    change_column :time_frames, :end_at, :string
+  def up
+    change_column :time_frames, :start_at, :string, :null => false
+    change_column :time_frames, :end_at, :string, :null => false
   end
 end

--- a/db/migrate/20210517060821_change_column_time_frame.rb
+++ b/db/migrate/20210517060821_change_column_time_frame.rb
@@ -3,4 +3,5 @@ class ChangeColumnTimeFrame < ActiveRecord::Migration[6.1]
     change_column :time_frames, :start_at, :string, :null => false
     change_column :time_frames, :end_at, :string, :null => false
   end
+  add_index  :time_frames, [:start_at, :end_at], unique: true
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_060821) do
+ActiveRecord::Schema.define(version: 2021_05_17_062203) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_060821) do
     t.string "end_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["start_at", "end_at"], name: "index_time_frames_on_start_at_and_end_at", unique: true
   end
 
   add_foreign_key "reservation_frames", "planners"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_060821) do
 
   create_table "reservation_frames", force: :cascade do |t|
     t.date "date"
-    t.boolean "is_deleted"
+    t.boolean "is_deleted", default: false, null: false
     t.integer "planner_id", null: false
     t.integer "time_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -50,8 +50,8 @@ ActiveRecord::Schema.define(version: 2021_05_17_060821) do
   end
 
   create_table "time_frames", force: :cascade do |t|
-    t.string "start_at"
-    t.string "end_at"
+    t.string "start_at", null: false
+    t.string "end_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_044615) do
+ActiveRecord::Schema.define(version: 2021_05_17_060821) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -50,8 +50,8 @@ ActiveRecord::Schema.define(version: 2021_05_17_044615) do
   end
 
   create_table "time_frames", force: :cascade do |t|
-    t.time "start_at"
-    t.time "end_at"
+    t.string "start_at"
+    t.string "end_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# 10時〜18:00まで30分単位で枠を作成(計16枠)
+16.times do |n|
+  TimeFrame.create!(
+      start_at: "#{(Time.zone.parse("10:00") + 60*30*n).strftime("%H:%M")}",
+      end_at: "#{(Time.zone.parse("10:30") + 60*30*n).strftime("%H:%M")}"
+  )
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 # 10時〜18:00まで30分単位で枠を作成(計16枠)
 16.times do |n|
   TimeFrame.create!(
-      start_at: (Time.zone.parse("10:00") + 30.minutes * n).strftime("%H:%M"),
-      end_at: (Time.zone.parse("10:30") + 30.minutes * n).strftime("%H:%M")
+    start_at: (Time.zone.parse("10:00") + 30.minutes * n).strftime("%H:%M"),
+    end_at: (Time.zone.parse("10:30") + 30.minutes * n).strftime("%H:%M")
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 # 10時〜18:00まで30分単位で枠を作成(計16枠)
 16.times do |n|
   TimeFrame.create!(
-      start_at: "#{(Time.zone.parse("10:00") + 60*30*n).strftime("%H:%M")}",
-      end_at: "#{(Time.zone.parse("10:30") + 60*30*n).strftime("%H:%M")}"
+      start_at: (Time.zone.parse("10:00") + 30.minutes * n).strftime("%H:%M"),
+      end_at: (Time.zone.parse("10:30") + 30.minutes * n).strftime("%H:%M")
   )
 end


### PR DESCRIPTION
## 対応issue
親issue：#14
close #16 
## issueの要約
clientがplannerの時間を抑えるために、planner側で受付可能な日時を指定する予約枠を作成できるようにする。
予約枠を作成する際に時間を指定するが、その際に時間枠を指定する。
その時間枠データを用意するためのPR。
## issueに対しておおまかに何をしたか
### 時間枠作成のseedの追記
- plannerが時間枠を作成する際にTimeFrameのidを使用
- rails db:seedを実行すると以下データを作成できる
![image](https://user-images.githubusercontent.com/42030915/118435528-1a1be300-b71a-11eb-8046-46d55c532c3f.png)
## レビュアーに注意して見てほしいこと 
- PRの意図が伝わっているか
- seedの書き方が適切か