### PR TITLE
client側のユーザー登録時にnameを登録できるようにする

### DIFF
--- a/app/views/clients/registrations/new.html.erb
+++ b/app/views/clients/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "clients/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label "ニックネーム" %><br />
+    <%= f.text_field :name, autofocus: true %>
+  </div>
+  
+  <div class="field">
     <%= f.label "メールアドレス" %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>


### PR DESCRIPTION
## 対応issue
親issue：#5
close #45  
## issueの要約
client側にログイン機能を実装したが(masterマージ済み)、planner側で誰から予約されたかが分かるようにnameを登録させたい。
client側でnameを登録できるようにするのがこのPRの目的。
## issueに対しておおまかに何をしたか
### viewを更新
すでに存在する[app/views/clients/registrations/new.html.erb](https://github.com/nisimotoryoga/pbl_fp_matching/pull/46/files#diff-40d85d68e48d091f54ba823a41ffed21e70b8b0513d34986799fe29981059e80)を更新
deviseの仕様でformを追加すれば登録できるようになる
※本来はcontroller対応も必要だが、Planner側の実装時に対応済みのため今回は不要
https://github.com/nisimotoryoga/pbl_fp_matching/pull/33/commits/1fc3895c467e233192efba859d332236b4c081c1
![image](https://user-images.githubusercontent.com/42030915/118585092-2e6fe680-b7d3-11eb-8deb-da99ee59c460.png)
