### PR TITLE
clientがplannerの予約枠を確認できる

### DIFF
--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -5,7 +5,7 @@ class PlannersController < ApplicationController
 
   def mypage
     @planner = current_planner
-    @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).includes(:time_frame)
+    @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).preload(:time_frame)
   end
 
   def index
@@ -13,8 +13,8 @@ class PlannersController < ApplicationController
   end
 
   def show
-    @planner = current_planner
-    @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).includes(:time_frame)
+    @planner = Planner.find(params[:id])
+    @reservation_frames = ReservationFrame.where(planner_id: params[:id]).order(:date).preload(:time_frame)
   end
 
 end

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -17,6 +17,4 @@ class PlannersController < ApplicationController
     @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).includes(:time_frame)
   end
 
-  def edit
-  end
 end

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -1,10 +1,15 @@
 class PlannersController < ApplicationController
   # Plannerでログインしていなければsign_inページにリダイレクトされる
-  before_action :authenticate_planner!
+  before_action :authenticate_planner!, only: :mypage
+  before_action :authenticate_client!, only: [:index, :show]
 
   def mypage
     @planner = current_planner
     @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).includes(:time_frame)
+  end
+
+  def index
+    @planners = Planner.all
   end
 
   def show

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -5,7 +5,7 @@ class PlannersController < ApplicationController
 
   def mypage
     @planner = current_planner
-    @reservation_frames = ReservationFrame.where(planner_id: current_planner.id).order(:date).preload(:time_frame)
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame)
   end
 
   def index
@@ -14,7 +14,7 @@ class PlannersController < ApplicationController
 
   def show
     @planner = Planner.find(params[:id])
-    @reservation_frames = ReservationFrame.where(planner_id: params[:id]).order(:date).preload(:time_frame)
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame)
   end
 
 end

--- a/app/views/planners/edit.html.erb
+++ b/app/views/planners/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Planners#edit</h1>
-<p>Find me in app/views/planners/edit.html.erb</p>

--- a/app/views/planners/index.html.erb
+++ b/app/views/planners/index.html.erb
@@ -1,0 +1,9 @@
+<div>
+  <%= render "shared/list" %>
+</div>
+
+<% @planners.each do |planner| %>
+  <%= planner.id %>
+  <%= planner.name %>
+  <%= link_to "選択", planner_path(planner) %>
+<% end %>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= render "shared/list_fp" %>
+  <%= render "shared/list" %>
 </div>
 
 <h1>ニックネーム：<%= @planner.name %></h1>

--- a/app/views/shared/_list.html.erb
+++ b/app/views/shared/_list.html.erb
@@ -1,4 +1,5 @@
 <% if client_signed_in? %> 
+  <%= link_to "FP一覧", planners_path %>
   <%= link_to "ログアウト", destroy_client_session_path , method: :delete %>
 <% else %>
   <%= link_to "新規登録", new_client_registration_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get "/top_fp" => "home#top_fp"
   
   devise_for :planners
-  resources :planners, only: [:index, :show, :edit] do
+  resources :planners, only: [:index, :show] do
     get :mypage, on: :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get "/top_fp" => "home#top_fp"
   
   devise_for :planners
-  resources :planners, only: [:show, :edit] do
+  resources :planners, only: [:index, :show, :edit] do
     get :mypage, on: :collection
   end
 

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Clients", type: :request do
     
     context "ログイン前" do
       it "sign_inにリダイレクトされる" do
-        get client_path(client.id)
+        get mypage_clients_path
         expect(response).to redirect_to new_client_session_path
       end
     end
@@ -15,11 +15,11 @@ RSpec.describe "Clients", type: :request do
         sign_in client
       end
       it "正常なレスポンスが返ってくる(200)" do
-        get client_path(client.id)
+        get mypage_clients_path
         expect(response.status).to eq 200
       end
       it "clientのnameが表示される" do
-        get client_path(client.id)
+        get mypage_clients_path
         expect(response.body).to include client.name
       end
     end

--- a/spec/requests/planners_spec.rb
+++ b/spec/requests/planners_spec.rb
@@ -25,4 +25,34 @@ RSpec.describe Planner, type: :request do
       end
     end
   end
+  
+  describe "FP一覧(index)のアクセス" do
+    let!(:planner) { FactoryBot.create(:planner) }
+    let!(:client) { FactoryBot.create(:client) }
+
+    context "ログインなし" do
+      it "clientのsign_inにリダイレクトされる" do
+        get planners_path
+        expect(response).to redirect_to new_client_session_path
+      end
+    end
+    context "Plannerでログイン" do
+      before do
+        sign_in planner
+      end
+      it "clientのsign_inにリダイレクトされる" do
+        get planners_path
+        expect(response).to redirect_to new_client_session_path
+      end
+    end
+    context "Clientでログイン" do
+      before do
+        sign_in client
+      end
+      it "正常なレスポンスが返ってくる(200)" do
+        get planners_path
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end

--- a/spec/requests/planners_spec.rb
+++ b/spec/requests/planners_spec.rb
@@ -2,30 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Planner, type: :request do
   describe "マイページのアクセス" do
-    before do
-      @planner = FactoryBot.create(:planner)
-    end
+    let!(:planner) { FactoryBot.create(:planner) }
+
     context "ログイン前" do
       it "sign_inにリダイレクトされる" do
-        get planner_path(@planner.id)
+        get mypage_planners_path
         expect(response).to redirect_to new_planner_session_path
       end
     end
     context "ログイン後" do
       before do
-        sign_in @planner
+        sign_in planner
       end
       it "正常なレスポンスが返ってくる(200)" do
-        get planner_path(@planner.id)
+        get mypage_planners_path
         expect(response.status).to eq 200
       end
       it "plannerのnameが表示される" do
-        get planner_path(@planner.id)
-        expect(response.body).to include @planner.name
+        get mypage_planners_path
+        expect(response.body).to include planner.name
       end
     end
   end
-  
+
   describe "FP一覧(index)のアクセス" do
     let!(:planner) { FactoryBot.create(:planner) }
     let!(:client) { FactoryBot.create(:client) }


### PR DESCRIPTION
## 対応issue
close #8
## issueの要約
clientがFPの設定した予約枠を予約する機能を作る。
FPなら誰でも良いということはないと思うので、今回は

1. FPを選択(FP一覧画面)
2. 選択したFPの予約枠を確認
3. 好きな枠を予約

という実装を行う。
このPRでは1と2の実装を目標としている

## issueに対しておおまかに何をしたか
### ①view作成・修正
- FP一覧を作成
![image](https://user-images.githubusercontent.com/42030915/118984919-f4f8d000-b9b8-11eb-8abf-f8e56da34d3e.png)

- 予約枠一覧ページの表示

※ 次のPRで2枚目でそれぞれの枠に予約ボタンを作り、そこから予約確認画面を経て予約できるようにする予定

![image](https://user-images.githubusercontent.com/42030915/118984962-ff1ace80-b9b8-11eb-9cd2-0b0355a0612e.png)

- ページ遷移用のヘッダーリンクを設定
FP一覧のリンクを追加

### ②planners_controllerの修正
- indexアクションを追加
- authenticateのアクション設定
  - planner：mypage(予約枠確認画面)
  - client：index(FP一覧), show(FPごとの予約枠一覧)
- N+1問題解決でincludesを使っていたところをpreload変更

### ③FP一覧のRSpec
テストは成功している
![image](https://user-images.githubusercontent.com/42030915/119084957-b1947500-ba3d-11eb-9ca2-ce4a90ebfc2a.png)

### ④使用していないeditに関する削除

## レビュアーに注意して見てほしいこと
※レイアウト(予約ステータス部分含む)・バリデーションは機能が揃ってから調整する予定です。
- eager_loadが適切か