### PR TITLE
clientが予約枠を選択して予約できる機能を実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,8 @@ Lint/StructNewOverride:
 
 Layout/LineLength:
   Max: 120
+  Exclude:
+  - 'db/schema.rb'
 
 Metrics/AbcSize:
   Exclude:

--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the reservations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -4,7 +4,7 @@ class ClientsController < ApplicationController
   
   def mypage
     @client = current_client
-    @reservations = @client.reservations.eager_load(:reservation_frame).order("reservation_frames.date")
+    @reservations = @client.reservations.eager_load(:reservation_frame).merge(Reservation.order(:date))
   end
   
   def edit

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -4,6 +4,7 @@ class ClientsController < ApplicationController
   
   def mypage
     @client = current_client
+    @reservations = @client.reservations.eager_load(:reservation_frame).order("reservation_frames.date")
   end
   
   def edit

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -4,7 +4,7 @@ class ClientsController < ApplicationController
   
   def mypage
     @client = current_client
-    @reservations = @client.reservations.eager_load(:reservation_frame).merge(Reservation.order(:date))
+    @reservations = @client.reservations.eager_load(:reservation_frame).order(:date)
   end
   
   def edit

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,7 +1,7 @@
 class ReservationsController < ApplicationController
   def new
     @reservation = Reservation.new
-    @reservation_frame = ReservationFrame.find(params[:reservation_frame_id])
+    @reservation_frame = ReservationFrameDecorator.decorate(ReservationFrame.find(params[:reservation_frame_id]))
   end
 
   def create

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -4,4 +4,19 @@ class ReservationsController < ApplicationController
     @reservation_frame = ReservationFrame.find(params[:reservation_frame_id])
   end
 
+  def create
+    reservation = Reservation.new(reservation_params)
+    reservation.client_id = current_client.id
+    if reservation.save
+      redirect_to mypage_clients_path
+    else
+      redirect_to planners_path
+    end
+  end
+
+  private
+
+  def reservation_params
+    params.require(:reservation).permit(:reservation_frame_id)
+  end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,12 +1,11 @@
 class ReservationsController < ApplicationController
   def new
-    @reservation = Reservation.new
+    @reservation = current_client.reservations.new
     @reservation_frame = ReservationFrameDecorator.decorate(ReservationFrame.find(params[:reservation_frame_id]))
   end
 
   def create
-    reservation = Reservation.new(reservation_params)
-    reservation.client_id = current_client.id
+    reservation = current_client.reservations.new(reservation_params)
     if reservation.save
       redirect_to mypage_clients_path
     else

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,0 +1,7 @@
+class ReservationsController < ApplicationController
+  def new
+    @reservation = Reservation.new
+    @reservation_frame = ReservationFrame.find(params[:reservation_frame_id])
+  end
+
+end

--- a/app/decorators/reservation_frame_decorator.rb
+++ b/app/decorators/reservation_frame_decorator.rb
@@ -1,0 +1,16 @@
+class ReservationFrameDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+  def period_of_time
+    reservation_frame.time_frame.start_at + "〜" + reservation_frame.time_frame.end_at
+  end
+
+end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,0 +1,2 @@
+module ReservationsHelper
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -3,4 +3,6 @@ class Client < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :reservations, dependent: :restrict_with_exception
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,4 @@
+class Reservation < ApplicationRecord
+  belongs_to :client
+  belongs_to :reservtion_frame
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,4 +1,4 @@
 class Reservation < ApplicationRecord
   belongs_to :client
-  belongs_to :reservtion_frame
+  belongs_to :reservation_frame
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -1,6 +1,7 @@
 class ReservationFrame < ApplicationRecord
   belongs_to :planner
   belongs_to :time_frame
+  has_one :reservations, dependent: :restrict_with_exception
 
   validates :date, presence: true
 

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -3,3 +3,20 @@
 </div>
 
 <h1>ニックネーム：<%= @client.name %></h1>
+
+予約一覧
+<table>
+  <tr>
+    <th>日付</th>
+    <th>開始時間</th>
+    <th>FP名</th>
+    <th></th>
+  </tr>
+  <% @reservations.each do |reservation| %>
+  <tr>
+    <td><%= reservation.reservation_frame.date %></td>
+    <td><%= reservation.reservation_frame.time_frame.start_at %></td>
+    <td><%= reservation.reservation_frame.planner.name %></td>
+  </tr>
+  <% end %>
+</table>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -16,6 +16,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>未予約/予約確定</td>
+    <td><%= link_to "選択", new_reservation_path(reservation_frame_id: reservation_frame) %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -8,7 +8,7 @@
   <dt>希望日</dt>
   <dd><%= @reservation_frame.date %></dd>
   <dt>時間</dt>
-  <dd><%= @reservation_frame.time_frame.start_at + "〜" + @reservation_frame.time_frame.end_at %></dd>
+  <dd><%= @reservation_frame.period_of_time %></dd>
 </dl>
 
 <%= link_to "キャンセル", planner_path(@reservation_frame.planner), class: "btn btn-primary" %>    

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,0 +1,19 @@
+<%= render "shared/list" %>
+
+<h1>予約確認</h1>
+
+<dl>
+  <dt>ファイナンシャルプランナー</dt>
+  <dd><%= @reservation_frame.planner.name %></dd>
+  <dt>希望日</dt>
+  <dd><%= @reservation_frame.date %></dd>
+  <dt>時間</dt>
+  <dd><%= @reservation_frame.time_frame.start_at + "〜" + @reservation_frame.time_frame.end_at %></dd>
+</dl>
+
+<%= link_to "キャンセル", planner_path(@reservation_frame.planner), class: "btn btn-primary" %>    
+
+<%= form_for @reservation, method: :post, url: reservations_path do |f| %>
+  <%= f.hidden_field :reservation_frame_id, :value => @reservation_frame.id %>
+  <%= f.submit "予約確定" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
     get :mypage, on: :collection
   end
   resources :reservation_frames, only: [:new, :create]
+  resources :reservations, only: [:new, :create]
 end

--- a/db/migrate/20210521005112_create_reservations.rb
+++ b/db/migrate/20210521005112_create_reservations.rb
@@ -1,0 +1,10 @@
+class CreateReservations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reservations do |t|
+      t.references :client, null: false, foreign_key: true
+      t.references :reservtion_frame, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210521005112_create_reservations.rb
+++ b/db/migrate/20210521005112_create_reservations.rb
@@ -2,7 +2,7 @@ class CreateReservations < ActiveRecord::Migration[6.1]
   def change
     create_table :reservations do |t|
       t.references :client, null: false, foreign_key: true
-      t.references :reservtion_frame, null: false, foreign_key: true
+      t.references :reservation_frame, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20210524121008_change_column_reservation.rb
+++ b/db/migrate/20210524121008_change_column_reservation.rb
@@ -1,0 +1,5 @@
+class ChangeColumnReservation < ActiveRecord::Migration[6.1]
+  def up
+    add_index  :reservations, [:client_id, :reservation_frame_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_21_005112) do
+ActiveRecord::Schema.define(version: 2021_05_24_121008) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2021_05_21_005112) do
     t.integer "reservation_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["client_id", "reservation_frame_id"], name: "index_reservations_on_client_id_and_reservation_frame_id", unique: true
     t.index ["client_id"], name: "index_reservations_on_client_id"
     t.index ["reservation_frame_id"], name: "index_reservations_on_reservation_frame_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,11 +51,11 @@ ActiveRecord::Schema.define(version: 2021_05_21_005112) do
 
   create_table "reservations", force: :cascade do |t|
     t.integer "client_id", null: false
-    t.integer "reservtion_frame_id", null: false
+    t.integer "reservation_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["client_id"], name: "index_reservations_on_client_id"
-    t.index ["reservtion_frame_id"], name: "index_reservations_on_reservtion_frame_id"
+    t.index ["reservation_frame_id"], name: "index_reservations_on_reservation_frame_id"
   end
 
   create_table "time_frames", force: :cascade do |t|
@@ -69,5 +69,5 @@ ActiveRecord::Schema.define(version: 2021_05_21_005112) do
   add_foreign_key "reservation_frames", "planners"
   add_foreign_key "reservation_frames", "time_frames"
   add_foreign_key "reservations", "clients"
-  add_foreign_key "reservations", "reservtion_frames"
+  add_foreign_key "reservations", "reservation_frames"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_062203) do
+ActiveRecord::Schema.define(version: 2021_05_21_005112) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -49,6 +49,15 @@ ActiveRecord::Schema.define(version: 2021_05_17_062203) do
     t.index ["time_frame_id"], name: "index_reservation_frames_on_time_frame_id"
   end
 
+  create_table "reservations", force: :cascade do |t|
+    t.integer "client_id", null: false
+    t.integer "reservtion_frame_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["client_id"], name: "index_reservations_on_client_id"
+    t.index ["reservtion_frame_id"], name: "index_reservations_on_reservtion_frame_id"
+  end
+
   create_table "time_frames", force: :cascade do |t|
     t.string "start_at", null: false
     t.string "end_at", null: false
@@ -59,4 +68,6 @@ ActiveRecord::Schema.define(version: 2021_05_17_062203) do
 
   add_foreign_key "reservation_frames", "planners"
   add_foreign_key "reservation_frames", "time_frames"
+  add_foreign_key "reservations", "clients"
+  add_foreign_key "reservations", "reservtion_frames"
 end

--- a/spec/decorators/reservation_frame_decorator_spec.rb
+++ b/spec/decorators/reservation_frame_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe ReservationFrameDecorator do
+end

--- a/spec/factories/reservation_frame.rb
+++ b/spec/factories/reservation_frame.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :reservation_frame do
+    association :planner
+    association :time_frame
+  end
+end

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Reservation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Clients", type: :request do
+RSpec.describe Client, type: :request do
   describe "マイページのアクセス" do
     let!(:client) { FactoryBot.create(:client) }
     

--- a/spec/requests/reservation_frames_spec.rb
+++ b/spec/requests/reservation_frames_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "ReservationFrames", type: :model do
+RSpec.describe ReservationFrame, type: :model do
   let!(:planner) { FactoryBot.create(:planner) }
   let!(:time_frame) { FactoryBot.create(:time_frame) }
   context 'date, time_frame_id, planner_id がすべて設定されている場合' do

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reservation, type: :model do
   context 'client_id, reservation_frame_id がすべて設定されている場合' do
     let!(:reservation_frame_id) { reservation_frame.id }
     let!(:client_id) { client.id }
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_valid }
   end
   context 'client_id が設定されていない場合' do
     let!(:reservation_frame_id) { reservation_frame.id }

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Reservations", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/reservations/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -1,35 +1,30 @@
 require 'rails_helper'
 
-RSpec.describe "Reservations", type: :model do
+RSpec.describe Reservation, type: :model do
   let!(:client) { FactoryBot.create(:client) }
   let!(:reservation_frame) { FactoryBot.create(:reservation_frame, date: Time.zone.now.to_date) }
+  subject(:reservation) { Reservation.new(reservation_frame_id: reservation_frame_id, client_id: client_id) }
 
   context 'client_id, reservation_frame_id がすべて設定されている場合' do
+    let!(:reservation_frame_id) { reservation_frame.id }
+    let!(:client_id) { client.id }
     it "reservationが有効" do
-      reservation = Reservation.new(
-        reservation_frame_id: reservation_frame.id,
-        client_id: client.id
-      )
-      expect(reservation).to be_valid
+      is_expected.to be_valid
     end
   end
   context 'client_id が設定されていない場合' do
+    let!(:reservation_frame_id) { reservation_frame.id }
+    let!(:client_id) { nil }
     it "reservationが無効" do
-      reservation = Reservation.new(
-        reservation_frame_id: reservation_frame.id,
-        client_id: nil
-      )
-      expect(reservation.valid?).to eq(false)
+      is_expected.not_to be_valid
     end
   end
   context 'reservation_frame_id が設定されていない場合' do
+    let!(:reservation_frame_id) { nil }
+    let!(:client_id) { client.id }
     it "reservationが無効" do
-      reservation = Reservation.new(
-        reservation_frame_id: nil,
-        client_id: client.id
-      )
-      expect(reservation.valid?).to eq(false)
+      is_expected.not_to be_valid
     end
   end
-
+  
 end

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -1,10 +1,34 @@
 require 'rails_helper'
 
-RSpec.describe "Reservations", type: :request do
-  describe "GET /new" do
-    it "returns http success" do
-      get "/reservations/new"
-      expect(response).to have_http_status(:success)
+RSpec.describe "Reservations", type: :model do
+  let!(:client) { FactoryBot.create(:client) }
+  let!(:reservation_frame) { FactoryBot.create(:reservation_frame, date: Time.zone.now.to_date) }
+
+  context 'client_id, reservation_frame_id がすべて設定されている場合' do
+    it "reservationが有効" do
+      reservation = Reservation.new(
+        reservation_frame_id: reservation_frame.id,
+        client_id: client.id
+      )
+      expect(reservation).to be_valid
+    end
+  end
+  context 'client_id が設定されていない場合' do
+    it "reservationが無効" do
+      reservation = Reservation.new(
+        reservation_frame_id: reservation_frame.id,
+        client_id: nil
+      )
+      expect(reservation.valid?).to eq(false)
+    end
+  end
+  context 'reservation_frame_id が設定されていない場合' do
+    it "reservationが無効" do
+      reservation = Reservation.new(
+        reservation_frame_id: nil,
+        client_id: client.id
+      )
+      expect(reservation.valid?).to eq(false)
     end
   end
 

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -8,23 +8,17 @@ RSpec.describe Reservation, type: :model do
   context 'client_id, reservation_frame_id がすべて設定されている場合' do
     let!(:reservation_frame_id) { reservation_frame.id }
     let!(:client_id) { client.id }
-    it "reservationが有効" do
-      is_expected.to be_valid
-    end
+    it { is_expected.not_to be_valid }
   end
   context 'client_id が設定されていない場合' do
     let!(:reservation_frame_id) { reservation_frame.id }
     let!(:client_id) { nil }
-    it "reservationが無効" do
-      is_expected.not_to be_valid
-    end
+    it { is_expected.not_to be_valid }
   end
   context 'reservation_frame_id が設定されていない場合' do
     let!(:reservation_frame_id) { nil }
     let!(:client_id) { client.id }
-    it "reservationが無効" do
-      is_expected.not_to be_valid
-    end
+    it { is_expected.not_to be_valid }
   end
   
 end


### PR DESCRIPTION
## 対応issue
close #9
## issueの要約
clientがFPの設定した予約枠を予約するところまで実現したい

今回は
1. FPを選択
2. 選択したFPの枠を確認
3. 好きな予約枠を選択
4. 予約確認画面を経て予約完了
5. mypageで予約を確認

という実装の流れだが、#56 で2まで終わっているので
このPRは3,4を実現することが目的。

## issueに対しておおまかに何をしたか

### ①テーブルの生成
rails コマンドでモデルを生成後にmigrateしてテーブルを作成

### ②modelの関連付け
https://github.com/nisimotoryoga/pbl_fp_matching/pull/57/commits/7bdf9289ca9ea1c4d8f27ebc176e5255367fbff1#diff-4ec829f3dadc01ce07332ae63c8a85a74fa6d01c2ca27118db63b2dffde41ea2R7
https://github.com/nisimotoryoga/pbl_fp_matching/pull/57/commits/7bdf9289ca9ea1c4d8f27ebc176e5255367fbff1#diff-34ff95f62baf8b8acba9fe24e78d42abe2cc8d522b1c85b181e144128e3dcff9R4

参考：
![image](https://user-images.githubusercontent.com/42030915/119066824-9a449000-ba1b-11eb-884c-662310af179e.png)

### ③FP詳細ページから予約前確認画面(Reservations/new.html.erb)の表示
![image](https://user-images.githubusercontent.com/42030915/119288937-9798a380-bc84-11eb-974a-95d5f7c5f0d8.png)
![image](https://user-images.githubusercontent.com/42030915/119288960-a2ebcf00-bc84-11eb-8dbe-c9fb78770bd9.png)


### ④clients/mypageに予約一覧を表示
![image](https://user-images.githubusercontent.com/42030915/119289036-cca4f600-bc84-11eb-8697-77c2236c163b.png)

### 予約に関するRSpec
テスト成功
![image](https://user-images.githubusercontent.com/42030915/119294770-2fe85580-bc90-11eb-87ef-100d3d230d7d.png)

## レビュアーに注意して見てほしいこと
※レイアウトやバリデーションは未対応です
※③の予約前確認画面のURLについて、クエリパラメータを利用しているのが気になると野田さんにFBいただきましたが、現時点では未対応です。レイアウトやバリデーションを検討する際に対応してみようと思います。
- アソシエーションの書き方
- [each文の書き方](https://github.com/nisimotoryoga/pbl_fp_matching/pull/57/commits/96a4c3ee5dac9e7444ea21247f16bf4c41027ee3#diff-44d055a7d2863cc4598f465375f8f9737ae1250b5ab157ec11b166e655bd8106R17-R19)