### PR TITLE
設定した予約枠とその予約ステータスを確認・キャンセルできる

### DIFF
--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -5,7 +5,7 @@ class PlannersController < ApplicationController
 
   def mypage
     @planner = current_planner
-    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).where(is_deleted: false)
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).is_deleted
   end
 
   def index

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -5,7 +5,7 @@ class PlannersController < ApplicationController
 
   def mypage
     @planner = current_planner
-    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).is_deleted
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).not_canceled
   end
 
   def index

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -5,7 +5,7 @@ class PlannersController < ApplicationController
 
   def mypage
     @planner = current_planner
-    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame)
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).where(is_deleted: false)
   end
 
   def index

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -8,8 +8,10 @@ class ReservationFramesController < ApplicationController
     @reservation_frame = ReservationFrame.new(reservation_frames_params)
     @reservation_frame.planner_id = current_planner.id
     if @reservation_frame.save
+      flash[:success] = "予約枠を登録しました。"
       redirect_to planner_path(current_planner.id)
     else
+      flash.now[:danger] = "予約枠の登録に失敗しました。"
       render :new
     end
   end
@@ -17,8 +19,10 @@ class ReservationFramesController < ApplicationController
   def hide
     reservation_frame = current_planner.reservation_frames.find(params[:id])
     if reservation_frame.update(is_deleted: true)
+      flash[:success] = "予約枠を削除しました。"
       redirect_to mypage_planners_path
     else
+      flash[:danger] = "予約枠の削除に失敗しました。"
       redirect_to mypage_planners_path
     end
   end

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -14,6 +14,15 @@ class ReservationFramesController < ApplicationController
     end
   end
 
+  def hide
+    reservation_frame = current_planner.reservation_frames.find(params[:id])
+    if reservation_frame.update(is_deleted: true)
+      redirect_to mypage_planners_path
+    else
+      redirect_to mypage_planners_path
+    end
+  end
+
   private
 
     def reservation_frames_params

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -28,7 +28,7 @@ class ReservationFramesController < ApplicationController
 
   private
 
-    def reservation_frames_params
-      params.require(:reservation_frame).permit(:date, :time_frame_id)
-    end
+  def reservation_frames_params
+    params.require(:reservation_frame).permit(:date, :time_frame_id)
+  end
 end

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -1,15 +1,14 @@
 class ReservationFramesController < ApplicationController
   
   def new
-    @reservation_frame = ReservationFrame.new
+    @reservation_frame = current_planner.reservation_frames.new
   end
 
   def create
-    @reservation_frame = ReservationFrame.new(reservation_frames_params)
-    @reservation_frame.planner_id = current_planner.id
+    @reservation_frame = current_planner.reservation_frames.new(reservation_frames_params)
     if @reservation_frame.save
       flash[:success] = "予約枠を登録しました。"
-      redirect_to planner_path(current_planner.id)
+      redirect_to mypage_planners_path
     else
       flash.now[:danger] = "予約枠の登録に失敗しました。"
       render :new

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -15,7 +15,7 @@ class ReservationFramesController < ApplicationController
     end
   end
 
-  def delete
+  def destroy
     reservation_frame = current_planner.reservation_frames.find(params[:id])
     if reservation_frame.update(canceled_at: Time.current)
       flash[:success] = "予約枠を削除しました。"

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -15,7 +15,7 @@ class ReservationFramesController < ApplicationController
     end
   end
 
-  def hide
+  def delete
     reservation_frame = current_planner.reservation_frames.find(params[:id])
     if reservation_frame.update(is_deleted: true)
       flash[:success] = "予約枠を削除しました。"

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -17,7 +17,7 @@ class ReservationFramesController < ApplicationController
 
   def delete
     reservation_frame = current_planner.reservation_frames.find(params[:id])
-    if reservation_frame.update(is_deleted: true)
+    if reservation_frame.update(canceled_at: Time.current)
       flash[:success] = "予約枠を削除しました。"
       redirect_to mypage_planners_path
     else

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -7,7 +7,7 @@ class ReservationFrame < ApplicationRecord
 
   scope :is_deleted, -> { where(:is_deleted => false) }
 
-  def is_reserved(reservation_frame_id)
-    return Reservation.exists?(reservation_frame_id: reservation_frame_id)
+  def is_reserved
+    return Reservation.exists?(reservation_frame_id: id)
   end
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -5,4 +5,5 @@ class ReservationFrame < ApplicationRecord
 
   validates :date, presence: true
 
+  scope :is_deleted, -> { where(:is_deleted => false) }
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -1,13 +1,13 @@
 class ReservationFrame < ApplicationRecord
   belongs_to :planner
   belongs_to :time_frame
-  has_one :reservations, dependent: :restrict_with_exception
+  has_one :reservation, dependent: :restrict_with_exception
 
   validates :date, presence: true
 
   scope :not_canceled, -> { where(canceled_at: nil) }
 
-  def is_reserved
-    return Reservation.exists?(reservation_frame_id: id)
+  def is_reserved?
+    return reservation.present?
   end
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -6,4 +6,8 @@ class ReservationFrame < ApplicationRecord
   validates :date, presence: true
 
   scope :is_deleted, -> { where(:is_deleted => false) }
+
+  def is_reserved(reservation_frame_id)
+    return Reservation.exists?(reservation_frame_id: reservation_frame_id)
+  end
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -8,6 +8,6 @@ class ReservationFrame < ApplicationRecord
   scope :not_canceled, -> { where(canceled_at: nil) }
 
   def is_reserved?
-    return reservation.present?
+    reservation.present?
   end
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -5,7 +5,7 @@ class ReservationFrame < ApplicationRecord
 
   validates :date, presence: true
 
-  scope :is_deleted, -> { where(:is_deleted => false) }
+  scope :not_canceled, -> { where(canceled_at: nil) }
 
   def is_reserved
     return Reservation.exists?(reservation_frame_id: id)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
   </head>
 
   <body>
+    <% flash.each do |message_type, message| %>
+      <%= message %>
+    <% end %>
+
     <%= yield %>
+    
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   </head>
 
   <body>
-    <% flash.each do |message_type, message| %>
+    <% flash.each do |_, message| %>
       <%= message %>
     <% end %>
 

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -16,7 +16,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>
-      <% if reservation_frame.is_reserved %>
+      <% if reservation_frame.is_reserved? %>
       予約済み
       <% else %>
       未予約

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -22,7 +22,7 @@
       未予約
       <% end %>
     </td>
-    <td><%= link_to  "キャンセル", delete_reservation_frame_path(reservation_frame.id), method: :put %></td>
+    <td><%= link_to  "キャンセル", reservation_frame_path(reservation_frame.id), method: :delete %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -16,7 +16,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>
-      <% if reservation_frame.is_reserved(reservation_frame.id) %>
+      <% if reservation_frame.is_reserved %>
       予約済み
       <% else %>
       未予約

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -16,7 +16,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>未予約/予約確定</td>
-    <td><%= link_to  "キャンセル", hide_reservation_frame_path(reservation_frame.id), method: :put %></td>
+    <td><%= link_to  "キャンセル", delete_reservation_frame_path(reservation_frame.id), method: :put %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -16,6 +16,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>未予約/予約確定</td>
+    <td><%= link_to  "キャンセル", hide_reservation_frame_path(reservation_frame.id), method: :put %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -15,7 +15,13 @@
   <tr>
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
-    <td>未予約/予約確定</td>
+    <td>
+      <% if reservation_frame.is_reserved(reservation_frame.id) %>
+      予約済み
+      <% else %>
+      未予約
+      <% end %>
+    </td>
     <td><%= link_to  "キャンセル", delete_reservation_frame_path(reservation_frame.id), method: :put %></td>
   </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,5 @@ Rails.application.routes.draw do
     get :mypage, on: :collection
   end
   resources :reservations, only: [:new, :create]
-  resources :reservation_frames, only: [:new, :create] do
-    delete :destroy, on: :member
-  end
+  resources :reservation_frames, only: [:new, :create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
   end
   resources :reservations, only: [:new, :create]
   resources :reservation_frames, only: [:new, :create] do
-    put :hide, on: :member
+    put :delete, on: :member
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   resources :clients, only: [:edit] do
     get :mypage, on: :collection
   end
-  resources :reservation_frames, only: [:new, :create]
   resources :reservations, only: [:new, :create]
+  resources :reservation_frames, only: [:new, :create] do
+    put :hide, on: :member
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
   end
   resources :reservations, only: [:new, :create]
   resources :reservation_frames, only: [:new, :create] do
-    put :delete, on: :member
+    delete :destroy, on: :member
   end
 end

--- a/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
+++ b/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
@@ -1,12 +1,12 @@
 class RenameIsDeletedColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
     remove_column :reservation_frames, :is_deleted
-    add_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null =>  true
+    add_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null => true
   end
   
   def down
     remove_column :reservation_frames, :canceled_at
-    add_column :reservation_frames, :is_deleted, :boolean, :default => false, :null =>  false
+    add_column :reservation_frames, :is_deleted, :boolean, :default => false, :null => false
   end
   
 end

--- a/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
+++ b/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
@@ -1,11 +1,12 @@
 class RenameIsDeletedColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
-    rename_column :reservation_frames, :is_deleted, :canceled_at
-    change_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null =>  true
+    remove_column :reservation_frames, :is_deleted
+    add_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null =>  true
   end
-
+  
   def down
-    rename_column :reservation_frames, :canceled_at, :is_deleted
+    remove_column :reservation_frames, :canceled_at
+    add_column :reservation_frames, :is_deleted, :boolean, :default => false, :null =>  false
   end
   
 end

--- a/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
+++ b/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
@@ -1,6 +1,11 @@
 class RenameIsDeletedColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
     rename_column :reservation_frames, :is_deleted, :canceled_at
-    change_column :reservation_frames, :canceled_at, :datetime, :default => '', :null =>  true
+    change_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null =>  true
   end
+
+  def down
+    rename_column :reservation_frames, :canceled_at, :is_deleted
+  end
+  
 end

--- a/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
+++ b/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
@@ -1,0 +1,6 @@
+class RenameIsDeletedColumnToReservationFrames < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :reservation_frames, :is_deleted, :canceled_at
+    change_column :reservation_frames, :canceled_at, :datetime, :default => '', :null =>  true
+  end
+end

--- a/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
+++ b/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
@@ -2,4 +2,8 @@ class AddIndexColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
     add_index  :reservation_frames, [:date, :planner_id, :time_frame_id], unique: true, name: "reservation_frames_index"
   end
+
+  def down
+    remove_index  :reservation_frames, name: :reservation_frames_index
+  end
 end

--- a/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
+++ b/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
@@ -1,0 +1,5 @@
+class AddIndexColumnToReservationFrames < ActiveRecord::Migration[6.1]
+  def up
+    add_index  :reservation_frames, [:date, :planner_id, :time_frame_id], unique: true, name: "reservation_frames_index"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_26_124149) do
+ActiveRecord::Schema.define(version: 2021_05_27_050817) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_05_26_124149) do
     t.integer "time_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["date", "planner_id", "time_frame_id"], name: "reservation_frames_index", unique: true
     t.index ["planner_id"], name: "index_reservation_frames_on_planner_id"
     t.index ["time_frame_id"], name: "index_reservation_frames_on_time_frame_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,11 +40,11 @@ ActiveRecord::Schema.define(version: 2021_05_27_050817) do
 
   create_table "reservation_frames", force: :cascade do |t|
     t.date "date"
-    t.datetime "canceled_at"
     t.integer "planner_id", null: false
     t.integer "time_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "canceled_at"
     t.index ["date", "planner_id", "time_frame_id"], name: "reservation_frames_index", unique: true
     t.index ["planner_id"], name: "index_reservation_frames_on_planner_id"
     t.index ["time_frame_id"], name: "index_reservation_frames_on_time_frame_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_24_121008) do
+ActiveRecord::Schema.define(version: 2021_05_26_124149) do
 
   create_table "clients", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2021_05_24_121008) do
 
   create_table "reservation_frames", force: :cascade do |t|
     t.date "date"
-    t.boolean "is_deleted", default: false, null: false
+    t.datetime "canceled_at"
     t.integer "planner_id", null: false
     t.integer "time_frame_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## 対応issue
#7 
## issueの要約
現状マイページには自身の予約枠が表示されているが、
＋α下記要件を追加したい。
- 予約を受けた枠も削除できる
→クライアント側は「キャンセルされました」と表示(このPRではやらない)
- 予約ステータスを表示
## issueに対しておおまかに何をしたか
### ①論理削除
・routing追加
・hideアクション追加
・mypage展開インスタンス変数にis_deleted: trueの条件追加
・link追加
![image](https://user-images.githubusercontent.com/42030915/119611098-2ba96d00-be35-11eb-9784-a5dc1ac5c1a5.png)
### ②エラーメッセージ表示
※レイアウトは未設定
![image](https://user-images.githubusercontent.com/42030915/119461870-1a038f00-bd7b-11eb-95ff-3c33932c01e6.png)
![image](https://user-images.githubusercontent.com/42030915/119461901-22f46080-bd7b-11eb-8630-4e45eda43542.png)

### ③リダイレクト先修正とコードのリファクタ
- リファクタ内容
>万が一にも他人のreservationを作ってしまわないようにするためにも、なるだけ current_client を起点にレコードを作っていくといいと思います 🙆‍♀️ (指摘コメント：https://github.com/nisimotoryoga/pbl_fp_matching/pull/57#discussion_r638419919)
## レビュアーに注意して見てほしいこと
- flash メッセージが適切か
- hide アクション名が適切か
(実際には消えないのでhideと命名)