### PR TITLE
クライアント側で予約キャンセルとステータスの表示に対応

### DIFF
--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -14,7 +14,7 @@ class PlannersController < ApplicationController
 
   def show
     @planner = Planner.find(params[:id])
-    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).is_deleted
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).not_canceled
   end
 
 end

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -14,7 +14,7 @@ class PlannersController < ApplicationController
 
   def show
     @planner = Planner.find(params[:id])
-    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame)
+    @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).is_deleted
   end
 
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -13,6 +13,17 @@ class ReservationsController < ApplicationController
     end
   end
 
+  def destroy
+    reservation_frame = current_client.reservations.find(params[:id])
+    if reservation_frame.destroy
+      flash[:success] = "予約をキャンセルしました。"
+      redirect_to mypage_clients_path
+    else
+      flash[:danger] = "予約のキャンセルに失敗しました。"
+      redirect_to mypage_clients_path
+    end
+  end
+
   private
 
   def reservation_params

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -14,8 +14,8 @@ class ReservationsController < ApplicationController
   end
 
   def destroy
-    reservation_frame = current_client.reservations.find(params[:id])
-    if reservation_frame.destroy
+    reservation = current_client.reservations.find(params[:id])
+    if reservation.destroy
       flash[:success] = "予約をキャンセルしました。"
       redirect_to mypage_clients_path
     else

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -12,7 +12,7 @@ class ReservationFrame < ApplicationRecord
   end
 
   def canceled?
-    self.canceled_at.nil?
+    self.canceled_at.present?
   end
   
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -10,4 +10,9 @@ class ReservationFrame < ApplicationRecord
   def is_reserved?
     reservation.present?
   end
+
+  def canceled?
+    self.canceled_at.nil?
+  end
+  
 end

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -17,7 +17,13 @@
     <td><%= reservation.reservation_frame.date %></td>
     <td><%= reservation.reservation_frame.time_frame.start_at %></td>
     <td><%= reservation.reservation_frame.planner.name %></td>
-    <td><%= link_to  "キャンセル", reservation_path(reservation.id), method: :delete %></td>
+    <td>
+      <% if reservation.reservation_frame.is_deleted == true %>
+        FPからキャンセルされました
+      <% else %>
+        <%= link_to  "キャンセル", reservation_path(reservation.id), method: :delete %>
+      <% end %>
+    </td>
   </tr>
   <% end %>
 </table>

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -18,10 +18,10 @@
     <td><%= reservation.reservation_frame.time_frame.start_at %></td>
     <td><%= reservation.reservation_frame.planner.name %></td>
     <td>
-      <% if reservation.reservation_frame.canceled_at != nil %>
-        FPからキャンセルされました
-      <% else %>
+      <% if reservation.reservation_frame.canceled? %>
         <%= link_to  "キャンセル", reservation_path(reservation), method: :delete %>
+      <% else %>
+        FPからキャンセルされました
       <% end %>
     </td>
   </tr>

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -19,9 +19,9 @@
     <td><%= reservation.reservation_frame.planner.name %></td>
     <td>
       <% if reservation.reservation_frame.canceled? %>
-        <%= link_to  "キャンセル", reservation_path(reservation), method: :delete %>
-      <% else %>
         FPからキャンセルされました
+      <% else %>
+        <%= link_to  "キャンセル", reservation_path(reservation), method: :delete %>
       <% end %>
     </td>
   </tr>

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -17,6 +17,7 @@
     <td><%= reservation.reservation_frame.date %></td>
     <td><%= reservation.reservation_frame.time_frame.start_at %></td>
     <td><%= reservation.reservation_frame.planner.name %></td>
+    <td><%= link_to  "キャンセル", reservation_path(reservation.id), method: :delete %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/clients/mypage.html.erb
+++ b/app/views/clients/mypage.html.erb
@@ -18,10 +18,10 @@
     <td><%= reservation.reservation_frame.time_frame.start_at %></td>
     <td><%= reservation.reservation_frame.planner.name %></td>
     <td>
-      <% if reservation.reservation_frame.is_deleted == true %>
+      <% if reservation.reservation_frame.canceled_at != nil %>
         FPからキャンセルされました
       <% else %>
-        <%= link_to  "キャンセル", reservation_path(reservation.id), method: :delete %>
+        <%= link_to  "キャンセル", reservation_path(reservation), method: :delete %>
       <% end %>
     </td>
   </tr>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -15,7 +15,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>
-      <% if reservation_frame.is_reserved(reservation_frame.id) %>
+      <% if reservation_frame.is_reserved? %>
         予約済み
       <% else %>
         <%= link_to "選択", new_reservation_path(reservation_frame_id: reservation_frame) %>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -8,15 +8,19 @@
   <tr>
     <th>日付</th>
     <th>開始時間</th>
-    <th>予約ステータス</th>
     <th></th>
   </tr>
   <% @reservation_frames.each do |reservation_frame| %>
   <tr>
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
-    <td>未予約/予約確定</td>
-    <td><%= link_to "選択", new_reservation_path(reservation_frame_id: reservation_frame) %></td>
+    <td>
+      <% if reservation_frame.is_reserved(reservation_frame.id) %>
+        予約済み
+      <% else %>
+        <%= link_to "選択", new_reservation_path(reservation_frame_id: reservation_frame) %>
+      <% end %>
+    </td>
   </tr>
   <% end %>
 </table>

--- a/app/views/shared/_list.html.erb
+++ b/app/views/shared/_list.html.erb
@@ -1,4 +1,5 @@
 <% if client_signed_in? %> 
+  <%= link_to "マイページ", mypage_clients_path %>
   <%= link_to "FP一覧", planners_path %>
   <%= link_to "ログアウト", destroy_client_session_path , method: :delete %>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :clients, only: [:edit] do
     get :mypage, on: :collection
   end
-  resources :reservations, only: [:new, :create]
+  
   resources :reservation_frames, only: [:new, :create, :destroy]
+  resources :reservations, only: [:new, :create, :destroy]
 end


### PR DESCRIPTION
## 対応issue
#6  
## issueの要約
現状マイページには自身の予約が表示されているが、
＋α下記要件を追加したい。
- 予約を削除できる
- 予約していたがFP側でキャンセルされたものについては「キャンセルされました」の表示
- 予約日が過去のものは実施済みのステータスにする

ユーザー情報の編集はこのPRでは対応しない
## issueに対しておおまかに何をしたか
### ①client周りのリファクタ
- 一覧表示で論理削除に対応
- ヘッダーリンクにマイページを追加
### ②planners/showの予約ステータスに応じた表示切り替え
予約されていたら(reservationにレコードが存在)予約済みと表示して予約できないようにする
![image](https://user-images.githubusercontent.com/42030915/119944675-837bdb80-bfcf-11eb-926e-69c50358aed1.png)

### ③clients/mypageの予約枠のステータスに応じた表示切り替え
reservation_frameのcanceled_atがnullではない場合、
「FPからキャンセルされました」という表示に変更しキャンセルできないようにする
![image](https://user-images.githubusercontent.com/42030915/119944483-4879a800-bfcf-11eb-99a6-f173d17918bb.png)

### ④予約キャンセル機能
(③の画像からの続き)
reservationのキャンセルは物理削除
![image](https://user-images.githubusercontent.com/42030915/119944729-98586f00-bfcf-11eb-8598-0290bc230c95.png)

## レビュアーに注意して見てほしいこと
- viewの条件分岐の書き方がきれいか
  - https://github.com/nisimotoryoga/pbl_fp_matching/pull/63/files#diff-44d055a7d2863cc4598f465375f8f9737ae1250b5ab157ec11b166e655bd8106R21-R25
  - https://github.com/nisimotoryoga/pbl_fp_matching/pull/63/files#diff-44d055a7d2863cc4598f465375f8f9737ae1250b5ab157ec11b166e655bd8106R21-R25