### PR TITLE
rubocopに従って大幅なリファクタ

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,8 +8,9 @@ AllCops:
   TargetRubyVersion: 2.7
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
-  DisabledByDefault: true
+  DisabledByDefault: false
   SuggestExtensions: false
+  NewCops: enable
   Exclude:
     - 'bin/**/*'
     - '**/tmp/**/*'
@@ -19,6 +20,9 @@ AllCops:
     - 'actionmailbox/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - '**/node_modules/**/*'
+  ### 以下は自動生成で手動で修正することがないので対象外
+    - 'db/schema.rb'
+    - config/puma.rb
 
 Rails:
   Enabled: true
@@ -153,3 +157,8 @@ Style/SpaceInsideBlockBraces:
 # https://msp-greg.github.io/rubocop/RuboCop/Cop/Style/MethodCallWithoutArgsParentheses.html
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
+
+## 以下defaltをオンにしてから追記したもの
+### ruby 3.0を使用しているので不要
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,9 +20,9 @@ AllCops:
     - 'actionmailbox/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - '**/node_modules/**/*'
-  ### 以下は自動生成で手動で修正することがないので対象外
+  # 以下は自動生成で手動で修正することがないので対象外
     - 'db/schema.rb'
-    - config/puma.rb
+    - 'config/puma.rb'
 
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # 追加
   gem 'pry-rails'
 end
@@ -40,16 +40,16 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
+  gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   # 追加
-  gem 'spring-commands-rspec'
+  gem 'pre-commit'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
-  gem 'pre-commit'
+  gem 'spring-commands-rspec'
 end
 
 group :test do
@@ -58,14 +58,14 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
-  
+
   # 追加
-  gem 'rspec-rails', '~> 5.0.0'
   gem 'factory_bot_rails'
+  gem 'rspec-rails', '~> 5.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # 追加
 gem 'devise'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  def after_sign_in_path_for(resource)
+  def after_sign_in_path_for(_resource)
     return mypage_planners_path if planner_signed_in?
+
     mypage_clients_path if client_signed_in?
   end
-  
+
   def after_sign_out_path_for(resource)
     resource == :planner ? top_fp_path : root_path
   end
@@ -14,7 +15,7 @@ class ApplicationController < ActionController::Base
 
   # ユーザー登録時に名前を登録できるようにする
   # https://github.com/heartcombo/devise#strong-parameters
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-  end
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    end
 end

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -1,13 +1,11 @@
 class ClientsController < ApplicationController
   # Clientでログインしていなければsign_inページにリダイレクトされる
   before_action :authenticate_client!
-  
+
   def mypage
     @client = current_client
     @reservations = @client.reservations.eager_load(:reservation_frame).order(:date)
   end
-  
-  def edit
-  end
-  
+
+  def edit; end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
-  def top
-  end
-  def top_fp
-  end
+  def top; end
+
+  def top_fp; end
 end

--- a/app/controllers/planners_controller.rb
+++ b/app/controllers/planners_controller.rb
@@ -1,7 +1,7 @@
 class PlannersController < ApplicationController
   # Plannerでログインしていなければsign_inページにリダイレクトされる
   before_action :authenticate_planner!, only: :mypage
-  before_action :authenticate_client!, only: [:index, :show]
+  before_action :authenticate_client!, only: %i[index show]
 
   def mypage
     @planner = current_planner
@@ -16,5 +16,4 @@ class PlannersController < ApplicationController
     @planner = Planner.find(params[:id])
     @reservation_frames = @planner.reservation_frames.order(:date).eager_load(:time_frame).not_canceled
   end
-
 end

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -1,5 +1,4 @@
 class ReservationFramesController < ApplicationController
-  
   def new
     @reservation_frame = current_planner.reservation_frames.new
   end
@@ -7,10 +6,10 @@ class ReservationFramesController < ApplicationController
   def create
     @reservation_frame = current_planner.reservation_frames.new(reservation_frames_params)
     if @reservation_frame.save
-      flash[:success] = "予約枠を登録しました。"
+      flash[:success] = '予約枠を登録しました。'
       redirect_to mypage_planners_path
     else
-      flash.now[:danger] = "予約枠の登録に失敗しました。"
+      flash.now[:danger] = '予約枠の登録に失敗しました。'
       render :new
     end
   end
@@ -18,17 +17,16 @@ class ReservationFramesController < ApplicationController
   def destroy
     reservation_frame = current_planner.reservation_frames.find(params[:id])
     if reservation_frame.update(canceled_at: Time.current)
-      flash[:success] = "予約枠を削除しました。"
-      redirect_to mypage_planners_path
+      flash[:success] = '予約枠を削除しました。'
     else
-      flash[:danger] = "予約枠の削除に失敗しました。"
-      redirect_to mypage_planners_path
+      flash[:danger] = '予約枠の削除に失敗しました。'
     end
+    redirect_to mypage_planners_path
   end
 
   private
 
-  def reservation_frames_params
-    params.require(:reservation_frame).permit(:date, :time_frame_id)
-  end
+    def reservation_frames_params
+      params.require(:reservation_frame).permit(:date, :time_frame_id)
+    end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -16,17 +16,16 @@ class ReservationsController < ApplicationController
   def destroy
     reservation = current_client.reservations.find(params[:id])
     if reservation.destroy
-      flash[:success] = "予約をキャンセルしました。"
-      redirect_to mypage_clients_path
+      flash[:success] = '予約をキャンセルしました。'
     else
-      flash[:danger] = "予約のキャンセルに失敗しました。"
-      redirect_to mypage_clients_path
+      flash[:danger] = '予約のキャンセルに失敗しました。'
     end
+    redirect_to mypage_clients_path
   end
 
   private
 
-  def reservation_params
-    params.require(:reservation).permit(:reservation_frame_id)
-  end
+    def reservation_params
+      params.require(:reservation).permit(:reservation_frame_id)
+    end
 end

--- a/app/decorators/reservation_frame_decorator.rb
+++ b/app/decorators/reservation_frame_decorator.rb
@@ -10,7 +10,6 @@ class ReservationFrameDecorator < Draper::Decorator
   #     end
   #   end
   def period_of_time
-    reservation_frame.time_frame.start_at + "〜" + reservation_frame.time_frame.end_at
+    "#{reservation_frame.time_frame.start_at} 〜 #{reservation_frame.time_frame.end_at}"
   end
-
 end

--- a/app/models/planner.rb
+++ b/app/models/planner.rb
@@ -3,6 +3,6 @@ class Planner < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
+
   has_many :reservation_frames, dependent: :restrict_with_exception
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -7,7 +7,7 @@ class ReservationFrame < ApplicationRecord
 
   scope :not_canceled, -> { where(canceled_at: nil) }
 
-  def is_reserved?
+  def reserved?
     reservation.present?
   end
 

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -12,7 +12,6 @@ class ReservationFrame < ApplicationRecord
   end
 
   def canceled?
-    self.canceled_at.present?
+    canceled_at?
   end
-  
 end

--- a/app/views/planners/mypage.html.erb
+++ b/app/views/planners/mypage.html.erb
@@ -16,13 +16,13 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>
-      <% if reservation_frame.is_reserved? %>
+      <% if reservation_frame.reserved? %>
       予約済み
       <% else %>
       未予約
       <% end %>
     </td>
-    <td><%= link_to  "キャンセル", reservation_frame_path(reservation_frame.id), method: :delete %></td>
+    <td><%= link_to "キャンセル", reservation_frame_path(reservation_frame.id), method: :delete %></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/planners/show.html.erb
+++ b/app/views/planners/show.html.erb
@@ -15,7 +15,7 @@
     <td><%= reservation_frame.date %></td>
     <td><%= reservation_frame.time_frame.start_at %></td>
     <td>
-      <% if reservation_frame.is_reserved? %>
+      <% if reservation_frame.reserved? %>
         予約済み
       <% else %>
         <%= link_to "選択", new_reservation_path(reservation_frame_id: reservation_frame) %>

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails/all"
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -22,13 +22,13 @@ module Pbl
     config.generators do |g|
       g.test_framework :rspec,
         # テストデータベースにレコードを作成するファイルの作成をスキップする
-        fixtures: false,
-        # ビュースペックを作成しない
-        view_specs: false,
-        # ヘルパーファイル用のスペックを作成しない
-        helper_specs: false,
-        # config/routes.rb用のスペックファイルの作成を省略(ルーティングが複雑になったら導入する)
-        routing_specs: false
+                       fixtures: false,
+                       # ビュースペックを作成しない
+                       view_specs: false,
+                       # ヘルパーファイル用のスペックを作成しない
+                       helper_specs: false,
+                       # config/routes.rb用のスペックファイルの作成を省略(ルーティングが複雑になったら導入する)
+                       routing_specs: false
 
         # コントローラースペックを生成したくない場合
         # controller_specs: false

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -88,8 +88,8 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -5,4 +5,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -129,7 +129,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 12
 
   # Set up a pepper to generate the hashed password.
-  
+
   # rubocop:disable Layout/LineLength
   # config.pepper = '4e5b9a3ef33a0c9b2915fb6f067de3cbe2e5e797e19d221748d16617f2fd75d8152f381607d5cebc47a29e595655466433b00abea21ea3a8849525fec3200ed6'
   # rubocop:enable Layout/LineLength

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  root "home#top"
-  get "/top_fp" => "home#top_fp"
-  
+  root 'home#top'
+  get '/top_fp' => 'home#top_fp'
+
   devise_for :planners
-  resources :planners, only: [:index, :show] do
+  resources :planners, only: %i[index show] do
     get :mypage, on: :collection
   end
 
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   resources :clients, only: [:edit] do
     get :mypage, on: :collection
   end
-  
-  resources :reservation_frames, only: [:new, :create, :destroy]
-  resources :reservations, only: [:new, :create, :destroy]
+
+  resources :reservation_frames, only: %i[new create destroy]
+  resources :reservations, only: %i[new create destroy]
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 )

--- a/db/migrate/20210506070235_devise_create_clients.rb
+++ b/db/migrate/20210506070235_devise_create_clients.rb
@@ -4,8 +4,8 @@ class DeviseCreateClients < ActiveRecord::Migration[6.1]
   def change
     create_table :clients do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20210510032609_devise_create_planners.rb
+++ b/db/migrate/20210510032609_devise_create_planners.rb
@@ -4,8 +4,8 @@ class DeviseCreatePlanners < ActiveRecord::Migration[6.1]
   def change
     create_table :planners do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20210517060821_change_column_time_frame.rb
+++ b/db/migrate/20210517060821_change_column_time_frame.rb
@@ -1,7 +1,7 @@
 class ChangeColumnTimeFrame < ActiveRecord::Migration[6.1]
   def up
-    change_column :time_frames, :start_at, :string, :null => false
-    change_column :time_frames, :end_at, :string, :null => false
+    change_column :time_frames, :start_at, :string, null: false
+    change_column :time_frames, :end_at, :string, null: false
   end
-  add_index  :time_frames, [:start_at, :end_at], unique: true
+  add_index :time_frames, %i[start_at end_at], unique: true
 end

--- a/db/migrate/20210517062203_change_column_reservation_frame.rb
+++ b/db/migrate/20210517062203_change_column_reservation_frame.rb
@@ -1,5 +1,5 @@
 class ChangeColumnReservationFrame < ActiveRecord::Migration[6.1]
   def up
-    change_column :reservation_frames, :is_deleted, :boolean, :default => false, :null => false
+    change_column :reservation_frames, :is_deleted, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20210524121008_change_column_reservation.rb
+++ b/db/migrate/20210524121008_change_column_reservation.rb
@@ -1,5 +1,5 @@
 class ChangeColumnReservation < ActiveRecord::Migration[6.1]
   def up
-    add_index  :reservations, [:client_id, :reservation_frame_id], unique: true
+    add_index :reservations, %i[client_id reservation_frame_id], unique: true
   end
 end

--- a/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
+++ b/db/migrate/20210526124149_rename_is_deleted_column_to_reservation_frames.rb
@@ -1,12 +1,11 @@
 class RenameIsDeletedColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
     remove_column :reservation_frames, :is_deleted
-    add_column :reservation_frames, :canceled_at, :datetime, :default => nil, :null => true
+    add_column :reservation_frames, :canceled_at, :datetime, default: nil, null: true
   end
-  
+
   def down
     remove_column :reservation_frames, :canceled_at
-    add_column :reservation_frames, :is_deleted, :boolean, :default => false, :null => false
+    add_column :reservation_frames, :is_deleted, :boolean, default: false, null: false
   end
-  
 end

--- a/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
+++ b/db/migrate/20210527050817_add_index_column_to_reservation_frames.rb
@@ -1,9 +1,9 @@
 class AddIndexColumnToReservationFrames < ActiveRecord::Migration[6.1]
   def up
-    add_index  :reservation_frames, [:date, :planner_id, :time_frame_id], unique: true, name: "reservation_frames_index"
+    add_index :reservation_frames, %i[date planner_id time_frame_id], unique: true, name: 'reservation_frames_index'
   end
 
   def down
-    remove_index  :reservation_frames, name: :reservation_frames_index
+    remove_index :reservation_frames, name: :reservation_frames_index
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 # 10時〜18:00まで30分単位で枠を作成(計16枠)
 16.times do |n|
   TimeFrame.create!(
-    start_at: (Time.zone.parse("10:00") + 30.minutes * n).strftime("%H:%M"),
-    end_at: (Time.zone.parse("10:30") + 30.minutes * n).strftime("%H:%M")
+    start_at: (Time.zone.parse('10:00') + 30.minutes * n).strftime('%H:%M'),
+    end_at: (Time.zone.parse('10:30') + 30.minutes * n).strftime('%H:%M')
   )
 end

--- a/spec/decorators/reservation_frame_decorator_spec.rb
+++ b/spec/decorators/reservation_frame_decorator_spec.rb
@@ -1,4 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe ReservationFrameDecorator do
-end
+# RSpec.describe ReservationFrameDecorator do
+# end

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :client do
-    email                           { "a@a" }
-    password                        { "abc1234" }
-    name                            { "ニックネーム" }
+    email                           { 'a@a' }
+    password                        { 'abc1234' }
+    name                            { 'ニックネーム' }
   end
 end

--- a/spec/factories/planners.rb
+++ b/spec/factories/planners.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :planner do
-    email                           { "a@a" }
-    password                        { "abc1234" }
-    name                            { "ニックネーム" }
+    email                           { 'a@a' }
+    password                        { 'abc1234' }
+    name                            { 'ニックネーム' }
   end
 end

--- a/spec/factories/time_frames.rb
+++ b/spec/factories/time_frames.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :time_frame do
-    start_at                { "10:00" }
-    end_at                  { "10:30" }
+    start_at                { '10:00' }
+    end_at                  { '10:30' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/clients_spec.rb
+++ b/spec/requests/clients_spec.rb
@@ -1,28 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Client, type: :request do
-  describe "マイページのアクセス" do
+  describe 'マイページのアクセス' do
     let!(:client) { FactoryBot.create(:client) }
-    
-    context "ログイン前" do
-      it "sign_inにリダイレクトされる" do
+
+    context 'ログイン前' do
+      it 'sign_inにリダイレクトされる' do
         get mypage_clients_path
         expect(response).to redirect_to new_client_session_path
       end
     end
-    context "ログイン後" do
+    context 'ログイン後' do
       before do
         sign_in client
       end
-      it "正常なレスポンスが返ってくる(200)" do
+      it '正常なレスポンスが返ってくる(200)' do
         get mypage_clients_path
         expect(response.status).to eq 200
       end
-      it "clientのnameが表示される" do
+      it 'clientのnameが表示される' do
         get mypage_clients_path
         expect(response.body).to include client.name
       end
     end
   end
-
 end

--- a/spec/requests/planners_spec.rb
+++ b/spec/requests/planners_spec.rb
@@ -1,54 +1,54 @@
 require 'rails_helper'
 
 RSpec.describe Planner, type: :request do
-  describe "マイページのアクセス" do
+  describe 'マイページのアクセス' do
     let!(:planner) { FactoryBot.create(:planner) }
 
-    context "ログイン前" do
-      it "sign_inにリダイレクトされる" do
+    context 'ログイン前' do
+      it 'sign_inにリダイレクトされる' do
         get mypage_planners_path
         expect(response).to redirect_to new_planner_session_path
       end
     end
-    context "ログイン後" do
+    context 'ログイン後' do
       before do
         sign_in planner
       end
-      it "正常なレスポンスが返ってくる(200)" do
+      it '正常なレスポンスが返ってくる(200)' do
         get mypage_planners_path
         expect(response.status).to eq 200
       end
-      it "plannerのnameが表示される" do
+      it 'plannerのnameが表示される' do
         get mypage_planners_path
         expect(response.body).to include planner.name
       end
     end
   end
 
-  describe "FP一覧(index)のアクセス" do
+  describe 'FP一覧(index)のアクセス' do
     let!(:planner) { FactoryBot.create(:planner) }
     let!(:client) { FactoryBot.create(:client) }
 
-    context "ログインなし" do
-      it "clientのsign_inにリダイレクトされる" do
+    context 'ログインなし' do
+      it 'clientのsign_inにリダイレクトされる' do
         get planners_path
         expect(response).to redirect_to new_client_session_path
       end
     end
-    context "Plannerでログイン" do
+    context 'Plannerでログイン' do
       before do
         sign_in planner
       end
-      it "clientのsign_inにリダイレクトされる" do
+      it 'clientのsign_inにリダイレクトされる' do
         get planners_path
         expect(response).to redirect_to new_client_session_path
       end
     end
-    context "Clientでログイン" do
+    context 'Clientでログイン' do
       before do
         sign_in client
       end
-      it "正常なレスポンスが返ってくる(200)" do
+      it '正常なレスポンスが返ってくる(200)' do
         get planners_path
         expect(response.status).to eq 200
       end

--- a/spec/requests/reservation_frames_spec.rb
+++ b/spec/requests/reservation_frames_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ReservationFrame, type: :model do
   let!(:planner) { FactoryBot.create(:planner) }
   let!(:time_frame) { FactoryBot.create(:time_frame) }
   context 'date, time_frame_id, planner_id がすべて設定されている場合' do
-    it "reservation_frameが有効" do
+    it 'reservation_frameが有効' do
       reservation_frame = ReservationFrame.new(
         date: Time.zone.now.to_date,
         time_frame_id: time_frame.id,
@@ -14,7 +14,7 @@ RSpec.describe ReservationFrame, type: :model do
     end
   end
   context 'time_frame_id が設定されていない場合' do
-    it "reservation_frameが無効" do
+    it 'reservation_frameが無効' do
       reservation_frame = ReservationFrame.new(
         date: Time.zone.now.to_date,
         time_frame_id: time_frame.id,
@@ -24,7 +24,7 @@ RSpec.describe ReservationFrame, type: :model do
     end
   end
   context 'planner_id が設定されていない場合' do
-    it "reservation_frameが無効" do
+    it 'reservation_frameが無効' do
       reservation_frame = ReservationFrame.new(
         date: Time.zone.now.to_date,
         time_frame_id: time_frame.id,
@@ -34,7 +34,7 @@ RSpec.describe ReservationFrame, type: :model do
     end
   end
   context 'date が設定されていない場合' do
-    it "reservation_frameが無効" do
+    it 'reservation_frameが無効' do
       reservation_frame = ReservationFrame.new(
         date: nil,
         time_frame_id: time_frame.id,

--- a/spec/requests/reservations_spec.rb
+++ b/spec/requests/reservations_spec.rb
@@ -20,5 +20,4 @@ RSpec.describe Reservation, type: :model do
     let!(:client_id) { client.id }
     it { is_expected.not_to be_valid }
   end
-  
 end


### PR DESCRIPTION
## 対応issue
close #67 
## issueの要約
```
  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
  # to ignore them, so only the ones explicitly set in this file are enabled.
  DisabledByDefault: true
```

これによってrubocopのデフォルト設定がオフになっていた
↓
 falseにしてみるととても怒られたのでこれを改修する
![image](https://user-images.githubusercontent.com/42030915/119957757-56362a00-bfdd-11eb-8e59-e239f626c8d5.png)

## issueに対しておおまかに何をしたか
### ①rubocopの警告に従って修正
### ②rubocopの設定ファイルを修正
- allcopの対象外
  - 以下は自動生成で手動で修正することがないので対象外
    - db/schema.rb
    - config/puma.rb

- Style/FrozenStringLiteralComment:
  - ruby 3.0を使用しているので不要
  - 参考：https://www.rubydoc.info/gems/rubocop/0.46.0/RuboCop/Cop/Style/FrozenStringLiteralComment
## レビュアーに注意して見てほしいこと
- rubocopの設定ファイル