### PR TITLE
バリデーションを洗い出して対応する

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,11 @@
 class HomeController < ApplicationController
-  def top; end
+  def top
+    redirect_to mypage_clients_path if client_signed_in?
+    redirect_to mypage_planners_path if planner_signed_in?
+  end
 
-  def top_fp; end
+  def top_fp
+    redirect_to mypage_clients_path if client_signed_in?
+    redirect_to mypage_planners_path if planner_signed_in?
+  end
 end

--- a/app/controllers/reservation_frames_controller.rb
+++ b/app/controllers/reservation_frames_controller.rb
@@ -5,6 +5,7 @@ class ReservationFramesController < ApplicationController
   end
 
   def create
+    @planner = current_planner
     @reservation_frame = current_planner.reservation_frames.new(reservation_frames_params)
     if @reservation_frame.save
       flash[:success] = '予約枠を登録しました。'

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,4 +1,6 @@
 class Reservation < ApplicationRecord
   belongs_to :client
   belongs_to :reservation_frame
+
+  validates :client_id, uniqueness: { scope: :reservation_frame_id }
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -3,9 +3,10 @@ class ReservationFrame < ApplicationRecord
   belongs_to :time_frame
   has_one :reservation, dependent: :restrict_with_exception
 
-  validates :date, presence: true
-
+  validates :date, presence: true, uniqueness: { scope: %i[time_frame_id planner] }
   scope :not_canceled, -> { where(canceled_at: nil) }
+
+  validate :sunday_is_closed, :saturday_is_shorttime, :invalid_of_date, on: :create
 
   def reserved?
     reservation.present?
@@ -13,5 +14,23 @@ class ReservationFrame < ApplicationRecord
 
   def canceled?
     canceled_at?
+  end
+
+  def sunday_is_closed
+    return unless date.wday.zero?
+
+    errors.add(:date, '：日曜日はゆっくり過ごしましょう。')
+  end
+
+  def saturday_is_shorttime
+    return unless date.wday == 6 && !time_frame_id.between?(3, 11)
+
+    errors.add(:date, '：土曜日は11時〜15時の間で指定してください。')
+  end
+
+  def invalid_of_date
+    return unless date <= Time.zone.today || date > Time.zone.today.since(1.year)
+
+    errors.add(:date, '：明日以降かつ1年以内で設定してください。')
   end
 end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -6,7 +6,9 @@ class ReservationFrame < ApplicationRecord
   validates :date, presence: true, uniqueness: { scope: %i[time_frame_id planner] }
   scope :not_canceled, -> { where(canceled_at: nil) }
 
-  validate :sunday_is_closed, :saturday_is_shorttime, :invalid_of_date, on: :create
+  validate :the_reservation_on_sunday_is_denied
+  validate :saturday_is_shorttime
+  validate :the_date_in_the_past_or_over_a_year_after_today_is_invalid
 
   def reserved?
     reservation.present?
@@ -16,21 +18,21 @@ class ReservationFrame < ApplicationRecord
     canceled_at?
   end
 
-  def sunday_is_closed
-    return unless date.wday.zero?
+  def the_reservation_on_sunday_is_denied
+    return unless date.sunday?
 
-    errors.add(:date, '：日曜日はゆっくり過ごしましょう。')
+    errors.add(:date, '日曜日はゆっくり過ごしましょう。')
   end
 
   def saturday_is_shorttime
     return unless date.wday == 6 && !time_frame_id.between?(3, 11)
 
-    errors.add(:date, '：土曜日は11時〜15時の間で指定してください。')
+    errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end
 
-  def invalid_of_date
+  def the_date_in_the_past_or_over_a_year_after_today_is_invalid
     return unless date <= Time.zone.today || date > Time.zone.today.since(1.year)
 
-    errors.add(:date, '：明日以降かつ1年以内で設定してください。')
+    errors.add(:date, '明日以降かつ1年以内で設定してください。')
   end
 end


### PR DESCRIPTION
## 対応issue
close #61 
## issueの要約
バリデーションに関してぱっと思いつくところしか対応していないので、
改めて洗い出し、全て対応していく

## issueに対しておおまかに何をしたか
### ①reservation_frames
- [x] date, time_frame のnullを拒否(過去すでに対応済み)
- [x] planner, date, time_frame_idのユニーク制約
- [x] 曜日で予約枠の制限
  - modelでカスタムバリデーションつくる
  - .wdayで判断
  - https://techacademy.jp/magazine/21762
      - 土曜：11:00〜15:00
      - 日曜：なし
### ②reservations
- [x] client_id, reservation_frame_idのユニーク制約
### ③ログイン中にtopページにアクセスさせない
- [x] ログインしているユーザーに応じてmypageにリダイレクトさせる
### ④その他リファクタ
- [x] render時にアカウント情報を渡すためにインスタンス変数の指定

## レビュアーに注意して見てほしいこと
- [カスタムバリデーション部分](https://github.com/nisimotoryoga/pbl_fp_matching/pull/72/files#diff-34ff95f62baf8b8acba9fe24e78d42abe2cc8d522b1c85b181e144128e3dcff9R19-R35)
  - シンプルに書くべきか、可読性の観点で分けたままで良いか