### PR TITLE
ClearDBの仕様に対応するため、time_frame_idではなくstart_atを利用

### DIFF
--- a/app/common_class/compare_time.rb
+++ b/app/common_class/compare_time.rb
@@ -1,0 +1,9 @@
+class CompareTime
+  def compare(time_frame)
+    today_str = Time.zone.today
+    start_at = Time.zone.parse("#{today_str} #{time_frame.start_at}")
+    time1 = Time.zone.parse("#{today_str} 11:00")
+    time2 = Time.zone.parse("#{today_str} 15:00")
+    start_at.between?(time1, time2)
+  end
+end

--- a/app/common_class/compare_time.rb
+++ b/app/common_class/compare_time.rb
@@ -1,9 +1,0 @@
-class CompareTime
-  def compare(time_frame)
-    today_str = Time.zone.today
-    start_at = Time.zone.parse("#{today_str} #{time_frame.start_at}")
-    time1 = Time.zone.parse("#{today_str} 11:00")
-    time2 = Time.zone.parse("#{today_str} 15:00")
-    start_at.between?(time1, time2)
-  end
-end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -28,7 +28,9 @@ class ReservationFrame < ApplicationRecord
   def saturday_is_shorttime
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if TimeString.compare(time_frame.start_at)
+
+    start_at = TimeString.new(time_frame.start_at)
+    return if TimeString.new('11:00') <= start_at && start_at <= TimeString.new('15:00')
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -26,10 +26,9 @@ class ReservationFrame < ApplicationRecord
   end
 
   def saturday_is_shorttime
-    compare_time = CompareTime.new
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if compare_time.compare(time_frame)
+    return if TimeString.compare(time_frame.start_at)
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -28,7 +28,7 @@ class ReservationFrame < ApplicationRecord
   def saturday_is_shorttime
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if time_frame_id.between?(3, 11)
+    return if time_frame.start_at.between?('11:00', '14:30')
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -28,7 +28,7 @@ class ReservationFrame < ApplicationRecord
   def saturday_is_shorttime
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if time_frame.start_at.between?('11:00', '14:30')
+    return if time_frame.start_at.to_datetime.between?('11:00', '14:30')
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -26,9 +26,10 @@ class ReservationFrame < ApplicationRecord
   end
 
   def saturday_is_shorttime
+    compare_time = CompareTime.new
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if time_frame.start_at.to_datetime.between?(DateTime.parse('11:00'), DateTime.parse('14:30'))
+    return if compare_time.compare(time_frame)
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/reservation_frame.rb
+++ b/app/models/reservation_frame.rb
@@ -28,7 +28,7 @@ class ReservationFrame < ApplicationRecord
   def saturday_is_shorttime
     return if date.nil? || time_frame_id.nil?
     return unless date.wday == 6
-    return if time_frame.start_at.to_datetime.between?('11:00', '14:30')
+    return if time_frame.start_at.to_datetime.between?(DateTime.parse('11:00'), DateTime.parse('14:30'))
 
     errors.add(:date, '土曜日は11時〜15時の間で指定してください。')
   end

--- a/app/models/time_string.rb
+++ b/app/models/time_string.rb
@@ -1,0 +1,7 @@
+class TimeString
+  include Comparable
+
+  def self.compare(time_str)
+    time_str.between?('11:00', '15:00')
+  end
+end

--- a/app/models/time_string.rb
+++ b/app/models/time_string.rb
@@ -1,7 +1,13 @@
 class TimeString
   include Comparable
+  attr_reader :time_str
 
-  def self.compare(time_str)
-    time_str.between?('11:00', '15:00')
+  def initialize(time_str)
+    today = Time.zone.today
+    @time_str = Time.zone.parse("#{today} #{time_str}")
+  end
+
+  def <=>(other)
+    time_str <=> other.time_str
   end
 end


### PR DESCRIPTION
## 対応issue
close #77 
## issueの要約
clearDBの仕様でidは10飛ばしになってしまう。
idでのバリデーションだとうまくいかないため、開始時間でバリデーションをかけることにする

![image](https://user-images.githubusercontent.com/42030915/121280397-2f4af280-c911-11eb-8008-cb4f87e30aa5.png)

## issueに対しておおまかに何をしたか
### saturday_is_shorttimeのロジック修正
## レビュアーに注意して見てほしいこと